### PR TITLE
Fix event trigger dependency false positive

### DIFF
--- a/automation_inspector/app/references.py
+++ b/automation_inspector/app/references.py
@@ -189,6 +189,8 @@ def collect_entity_references(
         references.setdefault(entity_id, set()).add(source)
 
     def scan_string(value: str, key: str | None) -> None:
+        if key == "event_type":
+            return
         exact = ENTITY_ID_RE.fullmatch(value.strip())
         if exact and key in COMPONENT_KEYS:
             return

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -74,3 +74,20 @@ def test_partitions_runtime_templates_from_static_targets() -> None:
         "entity_id": ["media_player.{{ room }}", "{{ sonos_speaker }}"]
     }
     assert references == {"media_player.office": {"action_target", "explicit"}}
+
+
+def test_ignores_event_type_but_keeps_event_entity_data() -> None:
+    config = {
+        "triggers": [
+            {
+                "trigger": "event",
+                "event_type": "timer.finished",
+                "event_data": {"entity_id": "timer.test"},
+            }
+        ],
+        "actions": [],
+    }
+
+    references = collect_entity_references(config, set())
+
+    assert references == {"timer.test": {"explicit"}}


### PR DESCRIPTION
Fixes #16.

## Summary
- ignore `event_type` values when extracting entity references
- keep `event_data.entity_id` dependencies visible
- add regression coverage for `timer.finished`

## Validation
- `python -m ruff format --check .`
- `python -m ruff check .`
- `python -m pytest tests/test_references.py`