### PR TITLE
Ignore description prose in dependencies

### DIFF
--- a/automation_inspector/app/references.py
+++ b/automation_inspector/app/references.py
@@ -189,7 +189,7 @@ def collect_entity_references(
         references.setdefault(entity_id, set()).add(source)
 
     def scan_string(value: str, key: str | None) -> None:
-        if key == "event_type":
+        if key in {"description", "event_type"}:
             return
         exact = ENTITY_ID_RE.fullmatch(value.strip())
         if exact and key in COMPONENT_KEYS:

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -91,3 +91,15 @@ def test_ignores_event_type_but_keeps_event_entity_data() -> None:
     references = collect_entity_references(config, set())
 
     assert references == {"timer.test": {"explicit"}}
+
+
+def test_ignores_entity_like_values_in_description() -> None:
+    config = {
+        "description": "Removed binary_sensor.old_tracker and notify.send_message here.",
+        "triggers": [{"trigger": "state", "entity_id": "sensor.real_dependency"}],
+        "actions": [],
+    }
+
+    references = collect_entity_references(config, set())
+
+    assert references == {"sensor.real_dependency": {"explicit"}}


### PR DESCRIPTION
Fixes #18.

Stacked on #20.

## Summary
- ignore automation `description` text during entity reference extraction
- keep real dependency fields scanned normally
- add regression coverage for entity-like prose and service names in descriptions

## Validation
- `python -m ruff format --check .`
- `python -m ruff check .`
- `python -m pytest tests/test_references.py`