### PR TITLE
Ignore Jinja context paths in dependencies

### DIFF
--- a/automation_inspector/app/references.py
+++ b/automation_inspector/app/references.py
@@ -27,6 +27,25 @@ ENTITY_VALUE_KEYS = {
     "humidity_entity_id",
 }
 
+JINJA_CONTEXT_ROOTS = frozenset(
+    {
+        "config",
+        "context",
+        "item",
+        "loop",
+        "now",
+        "repeat",
+        "state",
+        "states",
+        "this",
+        "trigger",
+        "utcnow",
+        "value_json",
+        "variables",
+        "wait",
+    }
+)
+
 STANDARD_DOMAINS = frozenset(
     {
         "air_quality",
@@ -197,12 +216,15 @@ def collect_entity_references(
         template_matches = set(TEMPLATE_ENTITY_RE.findall(value))
         for entity_id in template_matches:
             add(entity_id, "template")
-        if _is_template(value):
-            return
-        explicit_key = key in ENTITY_VALUE_KEYS
-        source = "template" if "{{" in value or "{%" in value else "configuration"
+        templated = _is_template(value)
+        # A templated value is resolved by Home Assistant at runtime, so an
+        # entity-shaped key cannot vouch for the dotted tokens it contains.
+        explicit_key = key in ENTITY_VALUE_KEYS and not templated
+        source = "template" if templated else "configuration"
         for entity_id in ENTITY_ID_RE.findall(value):
             domain = entity_id.split(".", 1)[0]
+            if templated and domain in JINJA_CONTEXT_ROOTS:
+                continue
             if explicit_key or entity_id in template_matches or domain in domains:
                 add(entity_id, "explicit" if explicit_key else source)
 

--- a/automation_inspector/app/references.py
+++ b/automation_inspector/app/references.py
@@ -197,6 +197,8 @@ def collect_entity_references(
         template_matches = set(TEMPLATE_ENTITY_RE.findall(value))
         for entity_id in template_matches:
             add(entity_id, "template")
+        if _is_template(value):
+            return
         explicit_key = key in ENTITY_VALUE_KEYS
         source = "template" if "{{" in value or "{%" in value else "configuration"
         for entity_id in ENTITY_ID_RE.findall(value):

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -138,3 +138,29 @@ def test_ignores_jinja_context_paths_but_keeps_literal_template_entities() -> No
         "input_boolean.window_pause": {"configuration"},
         "sensor.real_temperature": {"template"},
     }
+
+
+def test_keeps_template_entity_references_not_matched_by_helper_functions() -> None:
+    config = {
+        "conditions": [
+            {"condition": "template", "value_template": "{{ has_value('sensor.alpha') }}"},
+            {"condition": "template", "value_template": "{{ states.sensor.beta }}"},
+            {
+                "condition": "template",
+                "value_template": (
+                    "{% if is_state('binary_sensor.door','on') "
+                    "and has_value('sensor.temp') %}on{% endif %}"
+                ),
+            },
+        ],
+        "actions": [],
+    }
+
+    references = collect_entity_references(config, {"sensor", "binary_sensor"})
+
+    assert sorted(references) == [
+        "binary_sensor.door",
+        "sensor.alpha",
+        "sensor.beta",
+        "sensor.temp",
+    ]

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -103,3 +103,38 @@ def test_ignores_entity_like_values_in_description() -> None:
     references = collect_entity_references(config, set())
 
     assert references == {"sensor.real_dependency": {"explicit"}}
+
+
+def test_ignores_jinja_context_paths_but_keeps_literal_template_entities() -> None:
+    config = {
+        "conditions": [
+            {
+                "condition": "template",
+                "value_template": "{{ is_state('sensor.real_temperature', '20') }}",
+            }
+        ],
+        "actions": [
+            {
+                "repeat": {
+                    "for_each": [{"boolean": "input_boolean.window_pause"}],
+                    "sequence": [
+                        {
+                            "action": "input_boolean.turn_off",
+                            "target": {"entity_id": "{{ repeat.item.boolean }}"},
+                        },
+                        {
+                            "action": "logbook.log",
+                            "data": {"message": "Triggered by {{ trigger.entity_id }}"},
+                        },
+                    ],
+                }
+            }
+        ],
+    }
+
+    references = collect_entity_references(config, set())
+
+    assert references == {
+        "input_boolean.window_pause": {"configuration"},
+        "sensor.real_temperature": {"template"},
+    }


### PR DESCRIPTION
Fixes #17.

Stacked on #21.

## Summary
- stop broad entity regex extraction inside Jinja templates
- keep literal Home Assistant template helper references like `is_state('sensor.x', ...)`
- add regression coverage for `trigger.entity_id` and `repeat.item.boolean`

## Validation
- `python -m ruff format --check .`
- `python -m ruff check .`
- `python -m pytest tests/test_references.py`
