### PR TITLE
Inspect scripts alongside automations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Automation Inspector
 
-Automation Inspector is a read-only **Home Assistant App** that audits every loaded automation and, when available, every UI-managed automation in `automations.yaml`.
+Automation Inspector is a read-only **Home Assistant App** that audits every loaded automation and script and, when available, every UI-managed automation in `automations.yaml`.
 
-It resolves modern Home Assistant targets, checks dependency health, validates automation syntax, identifies Home Assistant 2026.7 migrations, and surfaces recent trace failures. All analysis runs locally inside Home Assistant; there is no telemetry or external data service.
+It resolves modern Home Assistant targets, checks dependency health, validates automation and script syntax, identifies Home Assistant 2026.7 migrations, and surfaces recent trace failures. All analysis runs locally inside Home Assistant; there is no telemetry or external data service.
 
 > [!IMPORTANT]
 > Version 1.0.0 is a breaking upgrade. It requires Home Assistant 2026.7.0 or newer, removes unauthenticated host-port access, and drops `armv7`. See [Migrating from 0.4.x](#migrating-from-04x).
@@ -31,6 +31,7 @@ _Screenshots use synthetic demo data; no Home Assistant instance data is include
 ## Highlights
 
 - **Complete automation config** — reads each loaded automation through the canonical `automation/config` WebSocket API instead of relying on state attributes.
+- **Script inspection** — reads loaded scripts through Home Assistant and checks their dependencies, actions, compatibility, and traces alongside automations.
 - **Current target model** — understands entity, device, area, floor, and label targets.
 - **Purpose-aware resolution** — filters resolved entities using the trigger, condition, or action target metadata Home Assistant itself publishes.
 - **Runtime-aware templates** — preserves templated target values as runtime-resolved metadata without reporting false missing entities.
@@ -122,6 +123,7 @@ One authenticated WebSocket connection batches:
 - entity, device, area, floor, and label registries;
 - entity integration sources and service descriptions;
 - loaded automation configurations;
+- loaded script configurations;
 - trigger and condition platform descriptions;
 - target extraction and config validation requests;
 - trace summaries and failed trace details.
@@ -130,7 +132,7 @@ One authenticated WebSocket connection batches:
 
 ## Report semantics
 
-An automation needs attention when one or more of these conditions apply:
+An automation or script needs attention when one or more of these conditions apply:
 
 - an entity reference is missing, unavailable, unknown, or disabled;
 - a device, area, floor, or label target no longer exists;
@@ -139,7 +141,7 @@ An automation needs attention when one or more of these conditions apply:
 - the latest stored run failed or contains template errors;
 - an entry exists in `automations.yaml` but did not load.
 
-“Unreferenced helpers” are cleanup candidates, not deletion instructions. A helper can still be used by scripts, dashboards, templates, integrations, or external clients.
+“Unreferenced helpers” are cleanup candidates, not deletion instructions. A helper can still be used by dashboards, templates, integrations, or external clients.
 
 ## HTTP API
 

--- a/automation_inspector/DOCS.md
+++ b/automation_inspector/DOCS.md
@@ -1,6 +1,6 @@
 # Automation Inspector App documentation
 
-Automation Inspector performs read-only health analysis of Home Assistant automations. Open it from the Home Assistant sidebar after starting the App.
+Automation Inspector performs read-only health analysis of Home Assistant automations and scripts. Open it from the Home Assistant sidebar after starting the App.
 
 ## Configuration
 
@@ -9,7 +9,7 @@ Automation Inspector performs read-only health analysis of Home Assistant automa
 | `refresh_interval` | 300 | Seconds between background inspections |
 | `request_timeout` | 15 | Timeout for each WebSocket response |
 | `include_disabled` | `true` | Analyze automations that are turned off |
-| `inspect_traces` | `true` | Retrieve details for recent failed traces |
+| `inspect_traces` | `true` | Retrieve details for recent failed automation and script traces |
 | `scan_automations_file` | `true` | Find UI-managed automations that did not load |
 
 Restart the App after changing options.
@@ -21,7 +21,7 @@ Restart the App after changing options.
 - **Unavailable / unknown** — Home Assistant has a state object, but its current state is unhealthy.
 - **Not loaded** — the automation exists in `automations.yaml` but has no runtime automation entity.
 - **Unresolved target** — a referenced device, area, floor, or label no longer exists.
-- **Runtime target** — a Jinja template such as `{{ sonos_speaker }}` that Home Assistant resolves only when the automation runs; this is informational, not a failure.
+- **Runtime target** — a Jinja template such as `{{ sonos_speaker }}` that Home Assistant resolves only when the automation or script runs; this is informational, not a failure.
 - **Compatibility** — Home Assistant validation failed or the configuration uses a removed/deprecated construct.
 - **Trace failure** — the latest retained execution ended in an error or contains template errors.
 
@@ -49,7 +49,7 @@ This is intentional in 1.0.0. Automation definitions and entity states are sensi
 
 ### Unreferenced helper appears in use elsewhere
 
-The helper list considers automations only. Scripts, dashboards, integrations, templates, and external clients are outside its scope. Always verify before deleting a helper.
+The helper list considers inspected automations and scripts only. Dashboards, integrations, templates, and external clients are outside its scope. Always verify before deleting a helper.
 
 ## Data handling
 

--- a/automation_inspector/app/dependency_map.py
+++ b/automation_inspector/app/dependency_map.py
@@ -185,28 +185,32 @@ def _latest_traces(traces: Iterable[dict[str, Any]]) -> dict[str, dict[str, Any]
     for trace in traces:
         if trace.get("not_triggered"):
             continue
+        domain = str(trace.get("domain") or "automation")
         item_id = trace.get("item_id")
         timestamp = trace.get("timestamp")
         if not isinstance(item_id, str) or not isinstance(timestamp, dict):
             continue
+        key = f"{domain}:{item_id}"
         start = str(timestamp.get("start", ""))
-        previous = latest.get(item_id)
+        previous = latest.get(key)
         previous_start = str((previous or {}).get("timestamp", {}).get("start", ""))
         if previous is None or start > previous_start:
-            latest[item_id] = trace
+            latest[key] = trace
     return latest
 
 
 def _trace_info(
+    domain: str,
     config_id: str | None,
     latest: Mapping[str, dict[str, Any]],
     details: Mapping[str, dict[str, Any]],
 ) -> dict[str, Any] | None:
-    if not config_id or config_id not in latest:
+    trace_key = f"{domain}:{config_id}" if config_id else None
+    if not trace_key or trace_key not in latest:
         return None
-    summary = latest[config_id]
+    summary = latest[trace_key]
     template_errors: list[str] = []
-    detail = details.get(config_id)
+    detail = details.get(trace_key)
     if isinstance(detail, dict):
         steps = detail.get("trace")
         if isinstance(steps, dict):
@@ -328,6 +332,7 @@ def _target_rows(
 
 def _analyze_automation(
     *,
+    domain: str,
     key: str,
     state: dict[str, Any] | None,
     configs: list[tuple[str, dict[str, Any]]],
@@ -383,7 +388,7 @@ def _analyze_automation(
             }
         )
 
-    trace = _trace_info(config_id, latest_traces, snapshot.trace_details)
+    trace = _trace_info(domain, config_id, latest_traces, snapshot.trace_details)
     trace_is_issue = bool(
         trace
         and (
@@ -396,11 +401,12 @@ def _analyze_automation(
     compatibility_errors = sum(
         1 for finding in compatibility if finding["severity"] in {"error", "warning"}
     )
+    state_value = str(state.get("state")) if state is not None else None
     if not loaded:
         status = "not_loaded"
-    elif state is not None and str(state.get("state")) == "on":
+    elif state_value == "on" or (domain == "script" and state_value != "unavailable"):
         status = "enabled"
-    elif state is not None and str(state.get("state")) == "unavailable":
+    elif state_value == "unavailable":
         status = "unavailable"
     else:
         status = "disabled"
@@ -409,6 +415,8 @@ def _analyze_automation(
     warnings: list[str] = []
     if loaded and key in snapshot.automation_config_errors:
         warnings.append(snapshot.automation_config_errors[key])
+    if loaded and domain == "script" and key in snapshot.script_config_errors:
+        warnings.append(snapshot.script_config_errors[key])
     if "use_blueprint" in primary_config:
         warnings.append("Blueprint analysis is limited to its configured inputs.")
 
@@ -417,6 +425,8 @@ def _analyze_automation(
     )
     return {
         "entity_id": key if loaded else None,
+        "domain": domain,
+        "item_type": "automation" if domain == "automation" else "script",
         "friendly_name": friendly_name,
         "enabled": status == "enabled",
         "loaded": loaded,
@@ -482,6 +492,7 @@ def build_inspection(snapshot: SourceSnapshot, settings: Settings) -> dict[str, 
 
     latest_traces = _latest_traces(snapshot.traces)
     automations: dict[str, dict[str, Any]] = {}
+    scripts: dict[str, dict[str, Any]] = {}
     matched_file_keys: set[str] = set()
     for entity_id, state in sorted(state_map.items()):
         if not entity_id.startswith("automation."):
@@ -508,9 +519,39 @@ def build_inspection(snapshot: SourceSnapshot, settings: Settings) -> dict[str, 
         if not configs:
             configs.append((f"attributes:{entity_id}", attributes))
         automations[entity_id] = _analyze_automation(
+            domain="automation",
             key=entity_id,
             state=state,
             configs=configs,
+            config_id=config_id,
+            loaded=True,
+            snapshot=snapshot,
+            state_map=state_map,
+            registry_map=registry_map,
+            known_domains=known_domains,
+            latest_traces=latest_traces,
+        )
+
+    for entity_id, state in sorted(state_map.items()):
+        if not entity_id.startswith("script."):
+            continue
+        attributes = state.get("attributes", {})
+        if not isinstance(attributes, dict):
+            attributes = {}
+        raw_config_id = attributes.get("id") or entity_id.split(".", 1)[1]
+        config_id = str(raw_config_id) if raw_config_id is not None else None
+        runtime_config = snapshot.script_configs.get(entity_id)
+
+        script_configs: list[tuple[str, dict[str, Any]]] = []
+        if runtime_config:
+            script_configs.append((f"runtime:{entity_id}", runtime_config))
+        else:
+            script_configs.append((f"attributes:{entity_id}", attributes))
+        scripts[entity_id] = _analyze_automation(
+            domain="script",
+            key=entity_id,
+            state=state,
+            configs=script_configs,
             config_id=config_id,
             loaded=True,
             snapshot=snapshot,
@@ -527,6 +568,7 @@ def build_inspection(snapshot: SourceSnapshot, settings: Settings) -> dict[str, 
         if key in automations:
             key = f"{key}:{file_automation.index}"
         automations[key] = _analyze_automation(
+            domain="automation",
             key=key,
             state=None,
             configs=[(file_automation.key, file_automation.config)],
@@ -540,7 +582,9 @@ def build_inspection(snapshot: SourceSnapshot, settings: Settings) -> dict[str, 
         )
 
     all_referenced = {
-        entity["id"] for automation in automations.values() for entity in automation["entities"]
+        entity["id"]
+        for item in [*automations.values(), *scripts.values()]
+        for entity in item["entities"]
     }
     unreferenced_helpers = []
     for entity_id in sorted(set(state_map) | set(registry_map)):
@@ -567,18 +611,18 @@ def build_inspection(snapshot: SourceSnapshot, settings: Settings) -> dict[str, 
         )
 
     entity_rows = [
-        entity for automation in automations.values() for entity in automation["entities"]
+        entity for item in [*automations.values(), *scripts.values()] for entity in item["entities"]
     ]
     compatibility_rows = [
         finding
-        for automation in automations.values()
-        for finding in automation["compatibility_issues"]
+        for item in [*automations.values(), *scripts.values()]
+        for finding in item["compatibility_issues"]
         if finding["severity"] in {"error", "warning"}
     ]
     unresolved_targets = sum(
         len(target[field])
-        for automation in automations.values()
-        for target in automation["targets"]
+        for item in [*automations.values(), *scripts.values()]
+        for target in item["targets"]
         for field in (
             "missing_devices",
             "missing_areas",
@@ -588,12 +632,12 @@ def build_inspection(snapshot: SourceSnapshot, settings: Settings) -> dict[str, 
     )
     trace_failures = sum(
         1
-        for automation in automations.values()
-        if automation["trace"]
+        for item in [*automations.values(), *scripts.values()]
+        if item["trace"]
         and (
-            automation["trace"].get("error")
-            or automation["trace"].get("template_errors")
-            or automation["trace"].get("script_execution") in {"error", "failed_max_runs"}
+            item["trace"].get("error")
+            or item["trace"].get("template_errors")
+            or item["trace"].get("script_execution") in {"error", "failed_max_runs"}
         )
     )
     ha_config = snapshot.home_assistant_config
@@ -608,8 +652,12 @@ def build_inspection(snapshot: SourceSnapshot, settings: Settings) -> dict[str, 
         },
         "summary": {
             "automations": len(automations),
+            "scripts": len(scripts),
+            "inspected_items": len(automations) + len(scripts),
             "enabled": sum(1 for item in automations.values() if item["enabled"]),
+            "enabled_scripts": sum(1 for item in scripts.values() if item["enabled"]),
             "disabled": sum(1 for item in automations.values() if item["status"] == "disabled"),
+            "disabled_scripts": sum(1 for item in scripts.values() if item["status"] == "disabled"),
             "unloaded": sum(1 for item in automations.values() if not item["loaded"]),
             "dependency_references": len(entity_rows),
             "unique_entities": len({row["id"] for row in entity_rows}),
@@ -620,6 +668,10 @@ def build_inspection(snapshot: SourceSnapshot, settings: Settings) -> dict[str, 
             "automations_with_issues": sum(
                 1 for item in automations.values() if item["issue_count"] > 0
             ),
+            "scripts_with_issues": sum(1 for item in scripts.values() if item["issue_count"] > 0),
+            "items_with_issues": sum(
+                1 for item in [*automations.values(), *scripts.values()] if item["issue_count"] > 0
+            ),
             "compatibility_issues": len(compatibility_rows),
             "unresolved_targets": unresolved_targets,
             "trace_failures": trace_failures,
@@ -627,6 +679,7 @@ def build_inspection(snapshot: SourceSnapshot, settings: Settings) -> dict[str, 
             "duration_ms": round((time.perf_counter() - started) * 1000, 1),
         },
         "automations": automations,
+        "scripts": scripts,
         "unreferenced_helpers": unreferenced_helpers,
         "orphans": [helper["id"] for helper in unreferenced_helpers],
         "warnings": snapshot.warnings,

--- a/automation_inspector/app/ha_client.py
+++ b/automation_inspector/app/ha_client.py
@@ -54,6 +54,8 @@ class SourceSnapshot:
     home_assistant_config: dict[str, Any]
     automation_configs: dict[str, dict[str, Any]] = field(default_factory=dict)
     automation_config_errors: dict[str, str] = field(default_factory=dict)
+    script_configs: dict[str, dict[str, Any]] = field(default_factory=dict)
+    script_config_errors: dict[str, str] = field(default_factory=dict)
     file_automations: list[FileAutomation] = field(default_factory=list)
     entity_registry: list[dict[str, Any]] = field(default_factory=list)
     device_registry: list[dict[str, Any]] = field(default_factory=list)
@@ -206,15 +208,17 @@ def _latest_traces(traces: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
     for trace in traces:
         if trace.get("not_triggered"):
             continue
+        domain = str(trace.get("domain") or "automation")
         item_id = trace.get("item_id")
         timestamp = trace.get("timestamp")
         if not isinstance(item_id, str) or not isinstance(timestamp, dict):
             continue
+        key = f"{domain}:{item_id}"
         start = str(timestamp.get("start", ""))
-        previous = latest.get(item_id)
+        previous = latest.get(key)
         previous_start = str((previous or {}).get("timestamp", {}).get("start", ""))
         if previous is None or start > previous_start:
-            latest[item_id] = trace
+            latest[key] = trace
     return latest
 
 
@@ -280,7 +284,8 @@ class HomeAssistantClient:
                     "label_registry": {"type": "config/label_registry/list"},
                     "entity_sources": {"type": "entity/source"},
                     "services": {"type": "get_services"},
-                    "traces": {"type": "trace/list", "domain": "automation"},
+                    "automation_traces": {"type": "trace/list", "domain": "automation"},
+                    "script_traces": {"type": "trace/list", "domain": "script"},
                 }
             )
 
@@ -301,11 +306,23 @@ class HomeAssistantClient:
                 for item in states
                 if str(item.get("entity_id", "")).startswith("automation.")
             )
+            script_ids = sorted(
+                str(item["entity_id"])
+                for item in states
+                if str(item.get("entity_id", "")).startswith("script.")
+            )
             config_results = await _call_in_batches(
                 session,
                 {
                     entity_id: {"type": "automation/config", "entity_id": entity_id}
                     for entity_id in automation_ids
+                },
+            )
+            script_config_results = await _call_in_batches(
+                session,
+                {
+                    entity_id: {"type": "script/config", "entity_id": entity_id}
+                    for entity_id in script_ids
                 },
             )
             automation_configs: dict[str, dict[str, Any]] = {}
@@ -317,6 +334,15 @@ class HomeAssistantClient:
                     automation_configs[entity_id] = config
                 else:
                     automation_config_errors[entity_id] = response.error or "Config unavailable"
+            script_configs: dict[str, dict[str, Any]] = {}
+            script_config_errors: dict[str, str] = {}
+            for entity_id, response in script_config_results.items():
+                result = response.result
+                config = result.get("config") if isinstance(result, dict) else None
+                if response.success and isinstance(config, dict):
+                    script_configs[entity_id] = config
+                else:
+                    script_config_errors[entity_id] = response.error or "Config unavailable"
 
             trigger_snapshot = await session.subscription_snapshot("trigger_platforms/subscribe")
             condition_snapshot = await session.subscription_snapshot(
@@ -340,6 +366,9 @@ class HomeAssistantClient:
             configs_for_analysis: dict[str, dict[str, Any]] = {
                 f"runtime:{entity_id}": config for entity_id, config in automation_configs.items()
             }
+            configs_for_analysis.update(
+                {f"runtime:{entity_id}": config for entity_id, config in script_configs.items()}
+            )
             configs_for_analysis.update(
                 {automation.key: automation.config for automation in file_automations}
             )
@@ -369,10 +398,17 @@ class HomeAssistantClient:
                 if request:
                     detail_requests[f"validation:{key}"] = request
 
-            traces = _list_result(base_results, "traces", warnings)
+            traces = [
+                dict(trace, domain="automation")
+                for trace in _list_result(base_results, "automation_traces", warnings)
+            ]
+            traces.extend(
+                dict(trace, domain="script")
+                for trace in _list_result(base_results, "script_traces", warnings)
+            )
             latest_traces = _latest_traces(traces)
             if self.settings.inspect_traces:
-                for item_id, trace in latest_traces.items():
+                for trace_key, trace in latest_traces.items():
                     if trace.get("script_execution") not in {
                         "error",
                         "aborted",
@@ -380,10 +416,12 @@ class HomeAssistantClient:
                     } and not trace.get("error"):
                         continue
                     run_id = trace.get("run_id")
+                    domain = str(trace.get("domain") or "automation")
+                    item_id = trace.get("item_id")
                     if isinstance(run_id, str):
-                        detail_requests[f"trace:{item_id}"] = {
+                        detail_requests[f"trace:{trace_key}"] = {
                             "type": "trace/get",
-                            "domain": "automation",
+                            "domain": domain,
                             "item_id": item_id,
                             "run_id": run_id,
                         }
@@ -422,6 +460,8 @@ class HomeAssistantClient:
                 home_assistant_config=config_response.result,
                 automation_configs=automation_configs,
                 automation_config_errors=automation_config_errors,
+                script_configs=script_configs,
+                script_config_errors=script_config_errors,
                 file_automations=file_automations,
                 entity_registry=_list_result(base_results, "entity_registry", warnings),
                 device_registry=_list_result(base_results, "device_registry", warnings),

--- a/automation_inspector/app/ha_client.py
+++ b/automation_inspector/app/ha_client.py
@@ -200,6 +200,8 @@ def _validation_request(config: Mapping[str, Any]) -> dict[str, Any] | None:
         value = config.get(plural, config.get(singular))
         if value is not None:
             request[plural] = value
+    if "actions" not in request and isinstance(config.get("sequence"), list):
+        request["actions"] = config["sequence"]
     return request if len(request) > 1 else None
 
 

--- a/automation_inspector/config.yaml
+++ b/automation_inspector/config.yaml
@@ -2,8 +2,8 @@ name: Automation Inspector
 version: 1.0.2
 slug: automation_inspector
 description: >-
-  Audits automation dependencies, targets, compatibility, and recent failures
-  without sending Home Assistant data outside your instance.
+  Audits automation and script dependencies, targets, compatibility, and recent
+  failures without sending Home Assistant data outside your instance.
 url: https://github.com/ITSpecialist111/Automation-Inspector
 arch:
   - aarch64

--- a/automation_inspector/translations/en.yaml
+++ b/automation_inspector/translations/en.yaml
@@ -10,7 +10,7 @@ configuration:
     description: Analyze automations that are currently turned off as well as enabled automations.
   inspect_traces:
     name: Inspect recent traces
-    description: Retrieve details for recent failed automation runs and template errors.
+    description: Retrieve details for recent failed automation and script runs and template errors.
   scan_automations_file:
     name: Scan automations.yaml
     description: Read the configuration file to report automations that failed to load.

--- a/automation_inspector/www/app.js
+++ b/automation_inspector/www/app.js
@@ -185,6 +185,8 @@ function renderMetrics() {
   const metrics = element("metrics");
   metrics.replaceChildren();
   const summary = state.data?.summary || {};
+  const itemCount = Number(summary.inspected_items || summary.automations || 0);
+  const scriptCount = Number(summary.scripts || 0);
   const unhealthyEntities =
     Number(summary.missing_entities || 0) +
     Number(summary.unavailable_entities || 0) +
@@ -192,15 +194,15 @@ function renderMetrics() {
     Number(summary.disabled_entities || 0);
   metrics.append(
     metricCard(
-      "Automations",
-      summary.automations,
-      `${summary.enabled || 0} enabled · ${summary.disabled || 0} disabled`,
+      "Inspected items",
+      itemCount,
+      `${summary.automations || 0} automations · ${scriptCount} scripts`,
     ),
     metricCard(
       "Need attention",
-      summary.automations_with_issues,
+      summary.items_with_issues ?? summary.automations_with_issues,
       `${summary.unloaded || 0} not loaded`,
-      summary.automations_with_issues ? "danger" : "",
+      (summary.items_with_issues ?? summary.automations_with_issues) ? "danger" : "",
     ),
     metricCard(
       "Dependency health",
@@ -280,7 +282,7 @@ function updateConnection(error = null) {
 }
 
 function automationSearchText(key, info) {
-  const parts = [key, info.friendly_name, info.status, info.config_id, info.mode];
+  const parts = [key, info.friendly_name, info.status, info.config_id, info.mode, info.item_type];
   (info.entities || []).forEach((entity) => {
     parts.push(entity.id, entity.name, entity.state, entity.status);
   });
@@ -301,6 +303,13 @@ function automationSearchText(key, info) {
   return parts.filter(Boolean).join(" ").toLocaleLowerCase();
 }
 
+function inspectionItems() {
+  return [
+    ...Object.entries(state.data?.automations || {}),
+    ...Object.entries(state.data?.scripts || {}),
+  ];
+}
+
 function daysSince(value) {
   const date = safeDate(value);
   return date ? (Date.now() - date.getTime()) / 86400000 : Number.POSITIVE_INFINITY;
@@ -312,7 +321,7 @@ function filteredAutomations() {
   const run = element("run-filter").value;
   const issuesOnly = element("issues-only").checked;
   const sort = element("sort-filter").value;
-  const entries = Object.entries(state.data?.automations || {}).filter(([key, info]) => {
+  const entries = inspectionItems().filter(([key, info]) => {
     if (status !== "all" && info.status !== status) return false;
     if (issuesOnly && Number(info.issue_count || 0) === 0) return false;
     const age = daysSince(info.last_triggered);
@@ -354,13 +363,17 @@ function entityLink(entity, preview = false) {
 }
 
 function automationHeader(key, info) {
+  const itemType = info.item_type === "script" ? "Script" : "Automation";
   const main = create("div", { className: "automation-main" });
   const heading = create("div", { className: "automation-heading" });
   heading.append(statusBadge(info.status));
   const title = create("div", { className: "automation-title-wrap" });
   title.append(
     create("h3", { className: "automation-title", text: info.friendly_name || key }),
-    create("span", { className: "automation-id", text: info.entity_id || `YAML · ${info.config_id || key}` }),
+    create("span", {
+      className: "automation-id",
+      text: `${itemType} · ${info.entity_id || `YAML · ${info.config_id || key}`}`,
+    }),
   );
   heading.append(title);
 
@@ -398,15 +411,16 @@ function automationHeader(key, info) {
 
   const actions = create("div", { className: "automation-actions" });
   if (info.loaded && info.config_id) {
+    const domain = info.item_type === "script" ? "script" : "automation";
     actions.append(
       link(
         "Edit",
-        homeAssistantUrl(`/config/automation/edit/${encodeURIComponent(info.config_id)}`),
+        homeAssistantUrl(`/config/${domain}/edit/${encodeURIComponent(info.config_id)}`),
         "button button-secondary small-button",
       ),
       link(
         "Traces",
-        homeAssistantUrl(`/config/automation/trace/${encodeURIComponent(info.config_id)}`),
+        homeAssistantUrl(`/config/${domain}/trace/${encodeURIComponent(info.config_id)}`),
         "button button-ghost small-button",
       ),
     );
@@ -611,10 +625,11 @@ function renderAutomations() {
   const loadMoreRow = element("load-more-row");
   loadMoreRow.classList.toggle("hidden", visible.length >= entries.length);
   element("load-more").textContent = `Show ${Math.min(PAGE_SIZE, entries.length - visible.length)} more`;
+  const total = inspectionItems().length;
   element("result-count").textContent =
-    entries.length === Object.keys(state.data.automations || {}).length
-      ? `${entries.length} automations inspected`
-      : `${entries.length} of ${Object.keys(state.data.automations || {}).length} automations match`;
+    entries.length === total
+      ? `${entries.length} items inspected`
+      : `${entries.length} of ${total} items match`;
 }
 
 function renderHelpers() {
@@ -698,6 +713,7 @@ async function loadInspection(force = false) {
     if (!body || body.schema_version !== 2 || typeof body.automations !== "object") {
       throw new Error("The server returned an unsupported inspection format.");
     }
+    if (!body.scripts || typeof body.scripts !== "object") body.scripts = {};
     state.data = body;
     state.etag = response.headers.get("ETag");
     state.lastLoadedAt = new Date();

--- a/automation_inspector/www/index.html
+++ b/automation_inspector/www/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light dark">
-  <meta name="description" content="Inspect Home Assistant automation dependencies, targets, compatibility, and traces.">
+  <meta name="description" content="Inspect Home Assistant automation and script dependencies, targets, compatibility, and traces.">
   <title>Automation Inspector</title>
   <script nonce="__CSP_NONCE__">
   (() => {
@@ -71,16 +71,16 @@
         <div class="workspace-heading">
           <div>
             <p class="eyebrow">Dependency explorer</p>
-            <h2 id="automation-title">Automations</h2>
+            <h2 id="automation-title">Automations & scripts</h2>
             <p class="section-note" id="result-count">Loading results…</p>
           </div>
         </div>
 
         <form class="filters" id="filter-form" role="search">
           <label class="search-field" for="search-input">
-            <span class="visually-hidden">Search automations and entities</span>
+            <span class="visually-hidden">Search automations, scripts, and entities</span>
             <svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="m20 20-4-4"/></svg>
-            <input id="search-input" type="search" autocomplete="off" placeholder="Search automation, entity, target, or issue…">
+            <input id="search-input" type="search" autocomplete="off" placeholder="Search automation, script, entity, target, or issue…">
           </label>
           <label class="field-label" for="status-filter">
             <span>Status</span>
@@ -123,14 +123,14 @@
         <div class="loading-state" id="loading-state">
           <span class="spinner" aria-hidden="true"></span>
           <div>
-            <strong>Inspecting automations</strong>
+            <strong>Inspecting automations and scripts</strong>
             <p>Resolving dependencies, targets, compatibility, and recent traces.</p>
           </div>
         </div>
 
         <div class="empty-state hidden" id="empty-state">
           <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 5h16v14H4zM8 9h8M8 13h5"/></svg>
-          <h3>No matching automations</h3>
+          <h3>No matching items</h3>
           <p>Change the filters or run a new inspection.</p>
         </div>
 
@@ -149,7 +149,7 @@
           </div>
           <span class="count-badge" id="helper-count">0</span>
         </div>
-        <p class="helper-intro">These helpers were not found in the inspected automations. Templates, scripts, dashboards, and external integrations may still use them, so verify before deleting.</p>
+        <p class="helper-intro">These helpers were not found in the inspected automations or scripts. Templates, dashboards, integrations, and external clients may still use them, so verify before deleting.</p>
         <div class="helper-grid" id="helper-list"></div>
       </section>
     </main>

--- a/tests/test_dependency_map.py
+++ b/tests/test_dependency_map.py
@@ -236,6 +236,75 @@ def test_duplicate_file_id_and_registry_only_helper_remain_visible() -> None:
     ]
 
 
+def test_build_inspection_includes_loaded_scripts() -> None:
+    script_config = {
+        "alias": "Night lights",
+        "sequence": [
+            {"service": "light.turn_on", "target": {"entity_id": "light.hall"}},
+            {"action": "notify.send_message", "data": {"message": "Done"}},
+        ],
+    }
+    snapshot = SourceSnapshot(
+        states=[
+            {
+                "entity_id": "script.night_lights",
+                "state": "off",
+                "attributes": {"friendly_name": "Night lights"},
+            },
+            {
+                "entity_id": "light.hall",
+                "state": "off",
+                "attributes": {"friendly_name": "Hall"},
+            },
+        ],
+        home_assistant_config={"version": "2026.7.2"},
+        script_configs={"script.night_lights": script_config},
+        traces=[
+            {
+                "domain": "script",
+                "item_id": "night_lights",
+                "run_id": "run-1",
+                "timestamp": {"start": "2026-07-10T10:00:00+00:00"},
+                "script_execution": "error",
+            }
+        ],
+        trace_details={"script:night_lights": {"trace": {"action/0": []}}},
+    )
+
+    report = build_inspection(snapshot, Settings())
+    script = report["scripts"]["script.night_lights"]
+
+    assert report["summary"]["automations"] == 0
+    assert report["summary"]["scripts"] == 1
+    assert report["summary"]["inspected_items"] == 1
+    assert script["item_type"] == "script"
+    assert script["status"] == "enabled"
+    assert {entity["id"] for entity in script["entities"]} == {"light.hall"}
+    assert {finding["code"] for finding in script["compatibility_issues"]} == {
+        "legacy_service_action_key"
+    }
+    assert script["trace"]["script_execution"] == "error"
+
+
+def test_excluding_disabled_automations_keeps_idle_scripts() -> None:
+    snapshot = SourceSnapshot(
+        states=[
+            {
+                "entity_id": "script.idle_script",
+                "state": "off",
+                "attributes": {"friendly_name": "Idle script"},
+            }
+        ],
+        home_assistant_config={"version": "2026.7.2"},
+        script_configs={"script.idle_script": {"alias": "Idle script", "sequence": []}},
+    )
+
+    report = build_inspection(snapshot, Settings(include_disabled=False))
+
+    assert list(report["scripts"]) == ["script.idle_script"]
+    assert report["scripts"]["script.idle_script"]["status"] == "enabled"
+
+
 def test_excluding_disabled_automation_does_not_report_its_file_as_unloaded() -> None:
     config = {"id": "off-id", "alias": "Off", "triggers": [], "actions": []}
     snapshot = SourceSnapshot(

--- a/tests/test_ha_client.py
+++ b/tests/test_ha_client.py
@@ -7,7 +7,7 @@ from websockets.asyncio.server import ServerConnection, serve
 from websockets.exceptions import ConnectionClosed, WebSocketException
 
 import app.ha_client as ha_client_module
-from app.ha_client import HomeAssistantClient, HomeAssistantConnectionError
+from app.ha_client import HomeAssistantClient, HomeAssistantConnectionError, _validation_request
 from app.references import target_key
 from app.settings import Settings
 
@@ -287,3 +287,21 @@ async def test_proxy_502_is_reported_as_temporary_startup_failure(monkeypatch) -
 
     assert "retry automatically" in str(raised.value)
     assert calls == 3
+
+
+def test_validation_request_validates_script_sequences() -> None:
+    sequence = [{"action": "light.turn_on"}]
+
+    script_request = _validation_request({"alias": "x", "sequence": sequence})
+
+    assert script_request is not None
+    assert script_request["actions"] == sequence
+
+    automation_request = _validation_request(
+        {"alias": "x", "actions": [{"action": "light.turn_off"}], "sequence": sequence}
+    )
+
+    assert automation_request is not None
+    assert automation_request["actions"] == [{"action": "light.turn_off"}]
+
+    assert _validation_request({"alias": "x"}) is None

--- a/tests/test_ha_client.py
+++ b/tests/test_ha_client.py
@@ -31,6 +31,10 @@ async def test_home_assistant_client_fetches_complete_websocket_snapshot() -> No
             },
         ],
     }
+    script_config = {
+        "alias": "WebSocket script",
+        "sequence": [{"action": "light.turn_on", "target": {"entity_id": "light.office"}}],
+    }
     received_types: list[str] = []
     resolved_targets: list[dict[str, object]] = []
 
@@ -57,6 +61,11 @@ async def test_home_assistant_client_fetches_complete_websocket_snapshot() -> No
                             "entity_id": "sensor.kitchen_battery",
                             "state": "12",
                             "attributes": {"device_class": "battery"},
+                        },
+                        {
+                            "entity_id": "script.websocket_script",
+                            "state": "off",
+                            "attributes": {"friendly_name": "WebSocket script"},
                         },
                     ]
                 elif request_type == "get_config":
@@ -94,17 +103,30 @@ async def test_home_assistant_client_fetches_complete_websocket_snapshot() -> No
                 elif request_type == "get_services":
                     result = {"light": {"turn_on": {"target": {"entity": [{"domain": ["light"]}]}}}}
                 elif request_type == "trace/list":
-                    result = [
-                        {
-                            "item_id": "one",
-                            "run_id": "run-1",
-                            "timestamp": {"start": "2026-07-10T10:00:00+00:00"},
-                            "script_execution": "error",
-                            "error": "Template failed",
-                        }
-                    ]
+                    if request["domain"] == "automation":
+                        result = [
+                            {
+                                "item_id": "one",
+                                "run_id": "run-1",
+                                "timestamp": {"start": "2026-07-10T10:00:00+00:00"},
+                                "script_execution": "error",
+                                "error": "Template failed",
+                            }
+                        ]
+                    else:
+                        result = [
+                            {
+                                "item_id": "websocket_script",
+                                "run_id": "run-script-1",
+                                "timestamp": {"start": "2026-07-10T11:00:00+00:00"},
+                                "script_execution": "error",
+                                "error": "Script failed",
+                            }
+                        ]
                 elif request_type == "automation/config":
                     result = {"config": automation_config}
+                elif request_type == "script/config":
+                    result = {"config": script_config}
                 elif request_type == "trigger_platforms/subscribe":
                     await websocket.send(
                         json.dumps(
@@ -170,7 +192,14 @@ async def test_home_assistant_client_fetches_complete_websocket_snapshot() -> No
                         "actions": {"valid": True, "error": None},
                     }
                 elif request_type == "trace/get":
-                    result = {"trace": {"action/0": [{"template_errors": ["Undefined variable"]}]}}
+                    if request["domain"] == "automation":
+                        result = {
+                            "trace": {"action/0": [{"template_errors": ["Undefined variable"]}]}
+                        }
+                    else:
+                        result = {
+                            "trace": {"sequence/0": [{"template_errors": ["Script variable"]}]}
+                        }
                 else:
                     raise AssertionError(f"Unexpected command: {request_type}")
 
@@ -198,6 +227,7 @@ async def test_home_assistant_client_fetches_complete_websocket_snapshot() -> No
 
     assert snapshot.home_assistant_config["version"] == "2026.7.2"
     assert snapshot.automation_configs["automation.websocket_automation"] == automation_config
+    assert snapshot.script_configs["script.websocket_script"] == script_config
     assert snapshot.device_registry[0]["id"] == "battery-device"
     assert snapshot.label_registry == []
     assert "Labels unavailable" in snapshot.warnings[0]
@@ -205,14 +235,20 @@ async def test_home_assistant_client_fetches_complete_websocket_snapshot() -> No
     assert snapshot.target_resolutions[key]["referenced_entities"] == ["sensor.kitchen_battery"]
     assert snapshot.target_resolutions[key]["primary_entities"] == ["sensor.kitchen_battery"]
     assert snapshot.validations["runtime:automation.websocket_automation"]["actions"]["valid"]
-    assert snapshot.trace_details["one"]["trace"]["action/0"][0]["template_errors"] == [
+    assert snapshot.trace_details["automation:one"]["trace"]["action/0"][0]["template_errors"] == [
         "Undefined variable"
     ]
+    assert snapshot.trace_details["script:websocket_script"]["trace"]["sequence/0"][0][
+        "template_errors"
+    ] == ["Script variable"]
     assert "unsubscribe_events" in received_types
+    assert "script/config" in received_types
     assert "trace/get" in received_types
     assert resolved_targets == [
         {"area_id": ["kitchen"]},
         {"area_id": ["kitchen"]},
+        {"entity_id": ["light.office"]},
+        {"entity_id": ["light.office"]},
     ]
 
 


### PR DESCRIPTION
Closes #8. Stacked on #22. Summary: fetch loaded scripts through script/config; include script dependencies, target resolution, validation, compatibility checks, and trace failures; add script counts to the API summary and merge scripts into the dependency explorer UI; update docs and app metadata. Validation: ruff format --check, ruff check, mypy, pytest --cov --cov-fail-under=75 (35 passed, 84.84%), node --check automation_inspector/www/app.js.