### PR TITLE
Release 1.1.0

### DIFF
--- a/automation_inspector/CHANGELOG.md
+++ b/automation_inspector/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 1.1.0 — 2026-07-28
+
+### Added
+
+- Inspect scripts alongside automations, including their entity dependencies, target resolution, native validation, compatibility findings, and recent trace failures.
+- Report script totals in the API summary (`scripts`, `inspected_items`, `items_with_issues`) and list scripts in the dependency explorer with **Edit** and **Traces** links.
+
+### Fixed
+
+- Stop reporting event trigger `event_type` values such as `timer.finished` as missing entities; the referenced `event_data` entity is still tracked.
+- Stop scanning automation `description` prose for entity references, so notes about removed entities no longer create missing dependencies.
+- Stop reporting Jinja runtime context variables such as `trigger.entity_id`, `repeat.item`, and `repeat.item.boolean` as missing entities, while still detecting real entities referenced inside templates.
+- Stop listing duplicate `automations.yaml` entries produced by YAML anchors and aliases as phantom "not loaded" automations that inflated the automation count.
+
+### Changed
+
+- Unreferenced helper detection now also accounts for helpers used by scripts, reducing false cleanup suggestions.
+
 ## 1.0.2 — 2026-07-12
 
 ### Fixed

--- a/automation_inspector/app/__init__.py
+++ b/automation_inspector/app/__init__.py
@@ -1,3 +1,3 @@
 """Automation Inspector application package."""
 
-APP_VERSION = "1.0.2"
+APP_VERSION = "1.1.0"

--- a/automation_inspector/config.yaml
+++ b/automation_inspector/config.yaml
@@ -1,5 +1,5 @@
 name: Automation Inspector
-version: 1.0.2
+version: 1.1.0
 slug: automation_inspector
 description: >-
   Audits automation and script dependencies, targets, compatibility, and recent


### PR DESCRIPTION
Bumps the app to 1.1.0 for the merged script inspection feature and the four dependency false-positive fixes. Adds the CHANGELOG entry. APP_VERSION and config.yaml version are kept in sync (enforced by test_project_contract). No functional code changes.