### PR TITLE
Bump dependencies and release 1.1.2

### DIFF
--- a/automation_inspector/CHANGELOG.md
+++ b/automation_inspector/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.1.2 — 2026-07-28
+
+### Changed
+
+- Update runtime dependencies: FastAPI 0.140.7 and websockets 16.1.1.
+- Update development dependencies: Ruff 0.16.0, mypy 2.3.0, anyio 4.14.2, and types-PyYAML 6.0.12.20260724.
+
 ## 1.1.1 — 2026-07-28
 
 ### Fixed

--- a/automation_inspector/app/__init__.py
+++ b/automation_inspector/app/__init__.py
@@ -1,3 +1,3 @@
 """Automation Inspector application package."""
 
-APP_VERSION = "1.1.1"
+APP_VERSION = "1.1.2"

--- a/automation_inspector/config.yaml
+++ b/automation_inspector/config.yaml
@@ -1,5 +1,5 @@
 name: Automation Inspector
-version: 1.1.1
+version: 1.1.2
 slug: automation_inspector
 description: >-
   Audits automation and script dependencies, targets, compatibility, and recent

--- a/automation_inspector/requirements.txt
+++ b/automation_inspector/requirements.txt
@@ -1,4 +1,4 @@
-fastapi==0.139.0
+fastapi==0.140.7
 PyYAML==6.0.3
 uvicorn==0.51.0
-websockets==16.1
+websockets==16.1.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,9 @@
 -r automation_inspector/requirements.txt
 
-anyio==4.14.1
+anyio==4.14.2
 httpx==0.28.1
-mypy==2.2.0
+mypy==2.3.0
 pytest==9.1.1
 pytest-cov==7.1.0
-ruff==0.15.21
-types-PyYAML==6.0.12.20260518
+ruff==0.16.0
+types-PyYAML==6.0.12.20260724


### PR DESCRIPTION
Updates pinned dependencies and ships them as 1.1.2. Runtime: fastapi 0.139.0 -> 0.140.7, websockets 16.1 -> 16.1.1. Dev: ruff 0.15.21 -> 0.16.0, mypy 2.2.0 -> 2.3.0, anyio 4.14.1 -> 4.14.2, types-PyYAML -> 6.0.12.20260724. Verified locally with the upgraded pins: ruff format/check, mypy, and 39 tests at 85.07 percent coverage all pass. Container rebuilt and smoke tested: runtime user is inspector, a root-owned 0600 /data/options.json is still read (987), GET /health returns ok and GET / returns 200 with the new FastAPI.